### PR TITLE
Update rolling_3_day_avg_amount.sql

### DIFF
--- a/rolling_3_day_avg_amount.sql
+++ b/rolling_3_day_avg_amount.sql
@@ -1,9 +1,13 @@
 /* Using this dataset, show the SQL query to find the rolling 3 day average transaction amount for each day in January 2021.  PostgreSQL v9.6 */
-SELECT transaction_date,
-  total_transaction_amount,
-  round(avg(total_transaction_amount) OVER (ORDER BY transaction_date ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)::numeric,2) AS rolling_3_day_avg_amount
+SELECT rolling_3_day_avg_amount
 FROM
-  (SELECT date(transaction_time) as transaction_date,
-    sum(transaction_amount) as total_transaction_amount
-  FROM transactions
-  GROUP BY date(transaction_time)) base
+  (SELECT transaction_date,
+    total_transaction_amount,
+    ROUND(AVG(total_transaction_amount) OVER (ORDER BY transaction_date ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)::numeric, 2) AS rolling_3_day_avg_amount
+    FROM
+      (SELECT DATE(transaction_time) AS transaction_date,
+        SUM(transaction_amount) AS total_transaction_amount
+      FROM transactions
+      GROUP BY DATE(transaction_time)) AS tbd
+   ) AS tbd_agg
+WHERE transaction_date = '2021-01-31';


### PR DESCRIPTION
Update query to only show the rolling 3 day average avmount for 1/31/2021, also reformat the SQL and rename aliases.